### PR TITLE
Allow base-compat 0.10.x, excpetion-0.10.x and lens 4.16.x

### DIFF
--- a/jsaddle-dom.cabal
+++ b/jsaddle-dom.cabal
@@ -1214,7 +1214,7 @@ library
     build-depends:
         base >=4.7.0.0 && <5,
         base-compat >=0.9.0 && <0.12,
-        exceptions >=0.8 && <0.9,
+        exceptions >=0.8 && <0.10,
         transformers >=0.2 && <0.6,
         text >=0.11.0.6 && <1.3,
         jsaddle >=0.9.3.0 && <0.10,

--- a/jsaddle-dom.cabal
+++ b/jsaddle-dom.cabal
@@ -1214,7 +1214,7 @@ library
     build-depends:
         base >=4.7.0.0 && <5,
         base-compat >=0.9.0 && <0.12,
-        exceptions >=0.8 && <0.10,
+        exceptions >=0.8 && <0.11,
         transformers >=0.2 && <0.6,
         text >=0.11.0.6 && <1.3,
         jsaddle >=0.9.3.0 && <0.10,

--- a/jsaddle-dom.cabal
+++ b/jsaddle-dom.cabal
@@ -1213,12 +1213,11 @@ library
                         JSDOM.Generated.XSLTProcessor as JSDOM.XSLTProcessor
     build-depends:
         base >=4.7.0.0 && <5,
-        base-compat >=0.9.0 && <0.11,
+        base-compat >=0.9.0 && <0.12,
         exceptions >=0.8 && <0.9,
         transformers >=0.2 && <0.6,
         text >=0.11.0.6 && <1.3,
         jsaddle >=0.9.3.0 && <0.10,
-        lens >=4.12.3 && <4.17
+        lens >=4.12.3 && <4.18
     default-language: Haskell2010
     hs-source-dirs: src
-


### PR DESCRIPTION
Allow base-compat 0.10.x, excpetion-0.10.x and lens 4.16.x   (in order to be compatible with stack lts-12.3)