### PR TITLE
fix: Only provide an arg to new FormData only if the form element isJust

### DIFF
--- a/jsaddle-dom.cabal
+++ b/jsaddle-dom.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.4
+cabal-version: 2.2
 name: jsaddle-dom
 version: 0.9.3.2
 build-type: Custom
@@ -36,6 +36,7 @@ library
         JSDOM.Custom.AudioContext
         JSDOM.Custom.Database
         JSDOM.Custom.DOMError
+        JSDOM.Custom.FormData
         JSDOM.Custom.Geolocation
         JSDOM.Custom.Navigator
         JSDOM.Custom.NavigatorUserMediaError
@@ -636,6 +637,7 @@ library
     reexported-modules: JSDOM.Custom.AudioContext as JSDOM.AudioContext,
                         JSDOM.Custom.Database as JSDOM.Database,
                         JSDOM.Custom.DOMError as JSDOM.DOMError,
+                        JSDOM.Custom.FormData as JSDOM.FormData,
                         JSDOM.Custom.Geolocation as JSDOM.Geolocation,
                         JSDOM.Custom.Navigator as JSDOM.Navigator,
                         JSDOM.Custom.NavigatorUserMediaError as JSDOM.NavigatorUserMediaError,
@@ -765,7 +767,6 @@ library
                         JSDOM.Generated.FocusEvent as JSDOM.FocusEvent,
                         JSDOM.Generated.FontFace as JSDOM.FontFace,
                         JSDOM.Generated.FontFaceSet as JSDOM.FontFaceSet,
-                        JSDOM.Generated.FormData as JSDOM.FormData,
                         JSDOM.Generated.GainNode as JSDOM.GainNode,
                         JSDOM.Generated.Gamepad as JSDOM.Gamepad,
                         JSDOM.Generated.GamepadButton as JSDOM.GamepadButton,

--- a/src/JSDOM/Custom/FormData.hs
+++ b/src/JSDOM/Custom/FormData.hs
@@ -1,0 +1,19 @@
+module JSDOM.Custom.FormData(
+    module Generated,
+    newFormData
+) where
+
+import Prelude ()
+import Prelude.Compat
+
+import JSDOM.Types
+import Data.Maybe (mapMaybe)
+import Language.Javascript.JSaddle (toJSVal, jsg, new)
+
+import JSDOM.Generated.FormData as Generated hiding (newFormData)
+
+
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData Mozilla FormData documentation> 
+newFormData :: (MonadDOM m) => Maybe HTMLFormElement -> m FormData
+newFormData form
+  = liftDOM (FormData <$> new (jsg "FormData") (mapMaybe (fmap toJSVal) [form]))


### PR DESCRIPTION
Without this, newFormData crashes if you give it nothing, as I experienced by Reflex.Dom.Xhr.FormData.postForms ( https://github.com/reflex-frp/reflex-dom/blob/develop/reflex-dom-core/src/Reflex/Dom/Xhr/FormData.hs#L37 ) crashing when in an obelisk project under ob run (with the usual `A JavaScript exception was thrown! (may not reach Haskell code)` error).

Is this the right way to spot override broken generated code? It'd be lovely if this could get merged and you could point me in the right direction to fix the generator because it feels like there are probably other instances of this bug around...

I dropped the cabal version because you didn't actually need 2.4 and it was breaking calling cabal2nix from the reflex platform that I had around. That's kind of just my problem and not yours, but it's good to use the minimum cabal version that you need because cabal doesn't have a very good forward compat story: https://github.com/haskell/cabal/issues/4899 