### PR TITLE
bumping bounds to build with ghc 9.2

### DIFF
--- a/jsaddle-dom.cabal
+++ b/jsaddle-dom.cabal
@@ -1219,11 +1219,11 @@ library
                         JSDOM.Generated.XSLTProcessor as JSDOM.XSLTProcessor
     build-depends:
         base >=4.7.0.0 && <5,
-        base-compat >=0.9.0 && <0.12,
+        base-compat >=0.9.0 && <0.13,
         exceptions >=0.8 && <0.11,
         transformers >=0.2 && <0.6,
         text >=0.11.0.6 && <1.3,
         jsaddle >=0.9.3.0 && <0.10,
-        lens >=4.12.3 && <4.20
+        lens >=4.12.3 && <5.2
     default-language: Haskell2010
     hs-source-dirs: src


### PR DESCRIPTION
It actually seems that ghc 9.2 can compile the huge Types module in only a few modules rather than s.t. like 40 minutes by the way :)