### PR TITLE
Fix Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -2,7 +2,7 @@ import Control.Monad (void)
 import Control.Concurrent (threadDelay, forkIO)
 import Data.Foldable (forM_)
 import Distribution.Simple
-       (simpleUserHooks, buildHook, defaultMainWithHooks)
+       (simpleUserHooks, buildHook, defaultMain)
 import System.IO (stdout, hFlush)
 
 -- We should split JSDOM.Types into smaller packages.


### PR DESCRIPTION
```
$ git rev-parse HEAD
bc6729c5e7a7c9319c783ed945664f663d25116b

$ runhaskell Setup.hs 
Setup.hs:12:8: error:
    Variable not in scope: defaultMain
    Suggested fix:
      Perhaps you want to add ‘defaultMain’ to the import list
      in the import of ‘Distribution.Simple’ (Setup.hs:(4,1)-(5,57)).
   |
12 | main = defaultMain
   |        ^^^^^^^^^^^
```

Introduced in https://github.com/ghcjs/jsaddle-dom/commit/93ccbe18f20331f5a2fd809e86b62839b9aaa1e0

Doing `cabal build` works fine since `build-type: Simple`, but nixpkgs' haskell infra seems to insist on building it so I guess we might as well cater to it for the sake of non haskell.nix builds.

This is the smallest diff that seems to fix it, but maybe the whole `Setup.hs` should just be trimmed down instead ?